### PR TITLE
[feat] Send heartbeat via API

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -3,7 +3,8 @@
     {
       "name": "main",
       "client_hooks": {
-        "aceEditEvent": "ep_connection_status/static/js/index"
+        "aceEditEvent": "ep_connection_status/static/js/index",
+        "postAceInit": "ep_connection_status/static/js/api"
       }
     }
   ]

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,0 +1,21 @@
+var EDITOR_HEARTBEAT = 'editor_heartbeat';
+var HEARTBEAT_INTERVAL = 3000;
+
+exports.postAceInit = function() {
+  setInterval(_triggerEditorHeartbeat, HEARTBEAT_INTERVAL)
+}
+
+var _triggerEditorHeartbeat = function() {
+  var message = {
+    type: EDITOR_HEARTBEAT,
+    timestamp: Date.now()
+  };
+
+  _triggerEvent(message);
+}
+
+var _triggerEvent = function _triggerEvent(message) {
+  // if there's a wrapper to Etherpad, send data to it; otherwise use Etherpad own window
+  var target = window.parent ? window.parent : window;
+  target.postMessage(message, '*');
+}


### PR DESCRIPTION
In this PR we send a heartbeat from Etherpad to Teksto via API. This is part of the implementation of the reconnection.
https://trello.com/c/eT9whfVe/1708