### PR TITLE
[feat] Create health check

### DIFF
--- a/checker.js
+++ b/checker.js
@@ -1,0 +1,35 @@
+var editorEvent = require('ep_webpack/editorEventEmitter').editorEvent;
+var webpackShared = require('ep_webpack/shared');
+
+/*
+here we declare all the checks needed to consider the editor service as
+healthy. From now, we only need to wait for webpack to create the bundle files
+*/
+var health_check = { webpack_is_ready: false };
+
+var WEBPACK_FILES_GENERATED_EVENT = webpackShared.WEBPACK_FILES_GENERATED_EVENT;
+
+var checker = function() {
+  this._listenToHealthCheckEvents();
+};
+
+checker.prototype._listenToHealthCheckEvents = function() {
+  var self = this;
+  var editorEmitter = new editorEvent().getEventEmitter();
+  editorEmitter.on(WEBPACK_FILES_GENERATED_EVENT, function() {
+    self.changeCheckerValue('webpack_is_ready', true);
+  });
+};
+
+checker.prototype.changeCheckerValue = function(key, value) {
+  health_check[key] = value;
+};
+
+checker.prototype.areAllChecksFullfilled = function(key, value) {
+  var checkValues = Object.values(health_check);
+  return !checkValues.includes(false);
+};
+
+exports.init = function() {
+  return new checker();
+};

--- a/ep.json
+++ b/ep.json
@@ -5,6 +5,9 @@
       "client_hooks": {
         "aceEditEvent": "ep_connection_status/static/js/index",
         "postAceInit": "ep_connection_status/static/js/api"
+      },
+      "hooks": {
+        "expressCreateServer": "ep_connection_status/index"
       }
     }
   ]

--- a/healthChecker.js
+++ b/healthChecker.js
@@ -9,11 +9,11 @@ var health_check = { webpack_is_ready: false };
 
 var WEBPACK_FILES_GENERATED_EVENT = webpackShared.WEBPACK_FILES_GENERATED_EVENT;
 
-var checker = function() {
+var healthChecker = function() {
   this._listenToHealthCheckEvents();
 };
 
-checker.prototype._listenToHealthCheckEvents = function() {
+healthChecker.prototype._listenToHealthCheckEvents = function() {
   var self = this;
   var editorEmitter = new editorEvent().getEventEmitter();
   editorEmitter.on(WEBPACK_FILES_GENERATED_EVENT, function() {
@@ -21,15 +21,15 @@ checker.prototype._listenToHealthCheckEvents = function() {
   });
 };
 
-checker.prototype.changeCheckerValue = function(key, value) {
+healthChecker.prototype.changeCheckerValue = function(key, value) {
   health_check[key] = value;
 };
 
-checker.prototype.areAllChecksFullfilled = function(key, value) {
+healthChecker.prototype.areAllChecksFullfilled = function(key, value) {
   var checkValues = Object.values(health_check);
   return !checkValues.includes(false);
 };
 
 exports.init = function() {
-  return new checker();
+  return new healthChecker();
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var checker = require('./checker');
+var healthChecker = require('./healthChecker');
 
 exports.expressCreateServer = function(hook_name, args, callback) {
-  var thisChecker = checker.init();
+  var thisChecker = healthChecker.init();
   args.app.get('/health', function(req, res) {
     var isHealth = thisChecker.areAllChecksFullfilled();
     if (isHealth) {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+var checker = require('./checker');
+
+exports.expressCreateServer = function(hook_name, args, callback) {
+  var thisChecker = checker.init();
+  args.app.get('/health', function(req, res) {
+    var isHealth = thisChecker.areAllChecksFullfilled();
+    if (isHealth) {
+      res.json({ code: 200, health: isHealth });
+    } else {
+      console.log({isHealth});
+    }
+  });
+};


### PR DESCRIPTION
On this PR we create a health check for the editor service. This
health check is useful to know when the editor is ready to receive
requests. The main issue is that the editor minimizes the client assets
on the first request. This is a problem because if a client does the
request before the CSS file is created a file without content will be
minimized. Then, all requests to this file afterwards will require the
same file minimized.
There is not a straight way to disable the minimization of some files on
Etherpad. It's all or nothing!

https://trello.com/c/GUMf9dFp/2481-acertar-erro-do-webpack-no-deploy